### PR TITLE
Add 'bind_dn' and 'bind_pw' params for authenticated LDAP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ It can be installed with:
 And then to enable it add the following to your settings.js file:
 
     adminAuth: require('node-red-contrib-ldap-auth').setup({
-		uri:'ldap://url.to.server', 
-		base: 'ou=group,o=company.com', 
-		filterTemplate: 'mail={{username}}'
-	}),
+      uri:'ldap://url.to.server',
+      base: 'ou=group,o=company.com',
+      filterTemplate: 'mail={{username}}'
+    }),
+
+If your LDAP server requires authentication before it can search, you can use the 'bind_dn' and 'bind_pw' parameters:
+
+    adminAuth: require('node-red-contrib-ldap-auth').setup({
+      uri:'ldap://url.to.server',
+      base: 'ou=group,o=company.com',
+      filterTemplate: 'mail={{username}}',
+      bind_dn: 'cn=authuser,o=company.com',
+      bind_pw: 'yourlittlesecret',
+    }),

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ If your LDAP server requires authentication before it can search, you can use th
       bind_dn: 'cn=authuser,o=company.com',
       bind_pw: 'yourlittlesecret',
     }),
+
+If your LDAP server is not using a verifiable SSL certificate, you can set the 'no_verify_ssl' parameter to 'true' (boolean) and it will not validate the connection.

--- a/node-red-contrib-ldap-auth.js
+++ b/node-red-contrib-ldap-auth.js
@@ -23,9 +23,6 @@ var ldap_bind_dn = null;
 var ldap_bind_pw = null;
 
 var options = {
-	'tlsOptions': {
-		'rejectUnauthorized': false,
-	}
 };
 
 var searchOpts = {
@@ -41,6 +38,11 @@ module.exports = {
 		if(args.bind_dn) {
 			ldap_bind_dn = args.bind_dn;
 			ldap_bind_pw = args.bind_pw;
+		}
+		if(args.no_verify_ssl) {
+			options.tlsOptions= {
+				'rejectUnauthorized': false,
+			};
 		}
 
 		return this;

--- a/node-red-contrib-ldap-auth.js
+++ b/node-red-contrib-ldap-auth.js
@@ -19,8 +19,13 @@ var ldapjs = require("ldapjs");
 
 
 var filterTemplate = '';
+var ldap_bind_dn = null;
+var ldap_bind_pw = null;
 
 var options = {
+	'tlsOptions': {
+		'rejectUnauthorized': false,
+	}
 };
 
 var searchOpts = {
@@ -33,6 +38,10 @@ module.exports = {
 		options.url = args.uri;
 		searchOpts.base = args.base;
 		filterTemplate = args.filterTemplate;
+		if(args.bind_dn) {
+			ldap_bind_dn = args.bind_dn;
+			ldap_bind_pw = args.bind_pw;
+		}
 
 		return this;
 	},
@@ -40,65 +49,88 @@ module.exports = {
 	users: function(username) {
 		return when.promise(function(resolve) {
 			var ldap = ldapjs.createClient(options);
-			var temp = {};
-			temp.username = username;
-			searchOpts.filter = mustache.render(filterTemplate, temp);
-			ldap.search(searchOpts.base,searchOpts,function(err, res){
-				var found = false;
+			var fn = function(err) {
 				if (err) {
-					console.log(err);
 					resolve(null);
 					ldap.unbind();
-				} else {
-					res.on('searchEntry', function(entry){
-						found = true;
-						resolve({ username: username, permissions: "*" });
-						ldap.unbind();
-					});
-					res.on('end', function(status) {
-						if (!found) {
-							resolve(null);
-							ldap.unbind();
-						}
-					});
 				}
-				
-			});
+				var temp = {};
+				temp.username = username;
+				searchOpts.filter = mustache.render(filterTemplate, temp);
+				ldap.search(searchOpts.base,searchOpts,function(err, res){
+					var found = false;
+					if (err) {
+						console.log(err);
+						resolve(null);
+						ldap.unbind();
+					} else {
+						res.on('searchEntry', function(entry){
+							found = true;
+							resolve({ username: username, permissions: "*" });
+							ldap.unbind();
+						});
+						res.on('end', function(status) {
+							if (!found) {
+								resolve(null);
+								ldap.unbind();
+							}
+						});
+					}
+				});
+			};
+			if(ldap_bind_dn) {
+				ldap.bind(ldap_bind_dn, ldap_bind_pw, fn);
+			}
+			else {
+				fn(null);
+			}
 		});
 	},
 	authenticate: function(username, password) {
 		return when.promise(function(resolve) {
 			var ldap = ldapjs.createClient(options);
-			var temp = {};
-			temp.username = username;
-			searchOpts.filter = mustache.render(filterTemplate, temp);
-			ldap.search(searchOpts.base,searchOpts,function(err, res){
-				var found = false;
+			var fn = function(err) {
 				if (err) {
-					console.log(err);
 					resolve(null);
 					ldap.unbind();
-				} else {
-					res.on('searchEntry', function(entry){
-						found = true;
-						ldap.bind(entry.dn, password, function(err){
-							if (!err) {
-								resolve({ username: username, permissions: "*" });
-								ldap.unbind();
-							} else {
+				}
+				var temp = {};
+				temp.username = username;
+				searchOpts.filter = mustache.render(filterTemplate, temp);
+				ldap.search(searchOpts.base,searchOpts,function(err, res){
+					var found = false;
+					if (err) {
+						console.log(err);
+						resolve(null);
+						ldap.unbind();
+					} else {
+						res.on('searchEntry', function(entry){
+							found = true;
+							ldap.bind(entry.dn, password, function(err){
+								if (!err) {
+									resolve({ username: username, permissions: "*" });
+									ldap.unbind();
+								} else {
+									resolve(null);
+									ldap.unbind();
+								}
+							});
+						});
+						res.on('end', function(status){
+							if (!found) {
 								resolve(null);
 								ldap.unbind();
 							}
 						});
-					});
-					res.on('end', function(status){
-						if (!found) {
-							resolve(null);
-							ldap.unbind();
-						}
-					});
-				}
-			});
+					}
+				});
+			};
+			if(ldap_bind_dn) {
+				ldap.bind(ldap_bind_dn, ldap_bind_pw, fn);
+			}
+			else {
+				fn(null);
+			}
 		});
 	},
 	default: function() {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "node-red-contrib-ldap-auth",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "LDAP authentication module for Node-RED ",
   "main": "node-red-contrib-ldap-auth.js",
   "dependencies": {
-    "mustache": "~2.0.0",
-    "ldapjs": "~0.7.1"
+    "when": "~3.8.0",
+    "mustache": "~2.3.0",
+    "ldapjs": "~1.0.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "LDAP authentication module for Node-RED ",
   "main": "node-red-contrib-ldap-auth.js",
   "dependencies": {
-    "when": "~3.8.0",
+    "when": "~3.7.0",
     "mustache": "~2.3.0",
     "ldapjs": "~1.0.0"
   },


### PR DESCRIPTION
This extends the functionality to allow for cases where the LDAP server requires authentication before it can search.