### PR TITLE
Handle connection exception when LDAP server is unavailable.

### DIFF
--- a/node-red-contrib-ldap-auth.js
+++ b/node-red-contrib-ldap-auth.js
@@ -51,6 +51,10 @@ module.exports = {
 	users: function(username) {
 		return when.promise(function(resolve) {
 			var ldap = ldapjs.createClient(options);
+			ldap.on('error', err => {
+				console.error(err);
+				resolve(null);
+			});
 			var fn = function(err) {
 				if (err) {
 					resolve(null);
@@ -91,6 +95,10 @@ module.exports = {
 	authenticate: function(username, password) {
 		return when.promise(function(resolve) {
 			var ldap = ldapjs.createClient(options);
+			ldap.on('error', err => {
+				console.error(err);
+				resolve(null);
+			});
 			var fn = function(err) {
 				if (err) {
 					resolve(null);


### PR DESCRIPTION
...otherwise this module crashes NodeRED if it cannot connect to the LDAP server successfully.

To reproduce, simply configure with a hostname that is not listening on the configured port (i.e. localhost). Output without this patch...

```
...
5 Nov 20:45:48 - [red] Uncaught Exception:
5 Nov 20:45:48 - Error: connect ECONNREFUSED 127.0.0.1:636
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1104:14)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-red@1.0.3 start: `node packages/node_modules/node-red/red.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the node-red@1.0.3 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/rossg/.npm/_logs/2019-11-05T13_45_48_104Z-debug.log
```