### PR TITLE
Anonymous read access to Node-Red UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Node-red-contrib-ldap-auth
---------------------------
+# Node-red-contrib-ldap-auth
 
 This is a Node-RED authentication plugin that uses LDAP as the backend user store.
 
@@ -15,7 +14,9 @@ And then to enable it add the following to your settings.js file:
       filterTemplate: 'mail={{username}}'
     }),
 
-If your LDAP server requires authentication before it can search, you can use the 'bind_dn' and 'bind_pw' parameters:
+## Bind Authentication
+
+If your LDAP server requires authentication before it can search, you can use the ``bind_dn`` and ``bind_pw`` parameters:
 
     adminAuth: require('node-red-contrib-ldap-auth').setup({
       uri:'ldap://url.to.server',
@@ -25,4 +26,8 @@ If your LDAP server requires authentication before it can search, you can use th
       bind_pw: 'yourlittlesecret',
     }),
 
-If your LDAP server is not using a verifiable SSL certificate, you can set the 'no_verify_ssl' parameter to 'true' (boolean) and it will not validate the connection.
+## Certificate Verification
+If your LDAP server is not using a verifiable SSL certificate, you can set the ``no_verify_ssl`` parameter to ``true`` (boolean) and it will not validate the connection.
+
+## Anonymous Access
+To allow anonymous read access to the NodeRed Admin UI, you can set the ``anon_read`` parameter to ``true``.

--- a/node-red-contrib-ldap-auth.js
+++ b/node-red-contrib-ldap-auth.js
@@ -22,6 +22,8 @@ var filterTemplate = '';
 var ldap_bind_dn = null;
 var ldap_bind_pw = null;
 
+var anon_read = false;
+
 var options = {
 };
 
@@ -44,7 +46,9 @@ module.exports = {
 				'rejectUnauthorized': false,
 			};
 		}
-
+        if(args.anon_read) {
+            anon_read = args.anon_read;
+        }
 		return this;
 	},
 	type: "credentials",
@@ -147,7 +151,11 @@ module.exports = {
         return when.promise(function(resolve) {
             // Resolve with the user object for the default user.
             // If no default user exists, resolve with null.
-            resolve(null);
+            if (anon_read) {
+                resolve({anonymous: true, permissions:"read"});
+            } else {
+                resolve(null);
+            }
         });
     }
 };


### PR DESCRIPTION
We needed to have the option for anonymous read access to the Node-Red Admin UI in addition to LDAP users. So I've added another option to enable that if necessary.

    adminAuth: require('node-red-contrib-ldap-auth').setup({
      uri:'ldap://url.to.server',
      base: 'ou=group,o=company.com',
      filterTemplate: 'mail={{username}}',
      bind_dn: 'cn=authuser,o=company.com',
      bind_pw: 'yourlittlesecret',
      anon_read: true,
    }),